### PR TITLE
Set mtime on 3 more repodata files

### DIFF
--- a/createrepo/__init__.py
+++ b/createrepo/__init__.py
@@ -1160,6 +1160,7 @@ class MetaDataGenerator:
         open_csum = misc.checksum(self.conf.sumtype, fo)
         fo.close()
         self._set_mtime(fo.name)
+        self._set_mtime(outfn)
 
         if self.conf.unique_md_filenames:
             (csum, outfn) = checksum_and_rename(outfn, self.conf.sumtype)
@@ -1396,6 +1397,7 @@ class MetaDataGenerator:
             fo = open(repofilepath, 'w')
             fo.write(repomd.dump_xml())
             fo.close()
+            self._set_mtime(repofilepath)
         except (IOError, OSError, TypeError), e:
             self.callback.errorlog(
                   _('Error saving temp file for repomd.xml: %s') % repofilepath)

--- a/genpkgmetadata.py
+++ b/genpkgmetadata.py
@@ -117,7 +117,7 @@ def parse_args(args, conf):
         action="append", help="tags to describe the repository itself")
     parser.add_option("--revision", default=None,
         help="user-specified revision for this repository")
-    parser.add_option("--set-timestamp-to-revision", default=None, type='int',
+    parser.add_option("--set-timestamp-to-revision", default=False, action="store_true",
         help="set timestamps in metadata and mtime of files to --revision value (date +%s format)")
     parser.add_option("--deltas", default=False, action="store_true",
         help="create delta rpms and metadata")


### PR DESCRIPTION
Hi,

I noticed your pull request #9 when searching for how to do a reproducible build with `createrepo` - perfect timing! I noticed though that the timestamps in `repomd.xml` weren't getting set for the `repodata/*comps.xml[.gz]` files. This fixes that and also sets the mtime for `repomd.xml` itself so that everything inside repodata is nice and consistent.

Also, your updated man page suggests that `--set-timestamp-to-revision` should be a boolean, so I've made that change.

Hope it's all helpful.